### PR TITLE
Fix property name clashes

### DIFF
--- a/models/ctmcs/cluster/premium.csl
+++ b/models/ctmcs/cluster/premium.csl
@@ -1,2 +1,2 @@
 // Long-run probability that premium QoS will be delivered
-"premium": S=? [ "premium" ];
+"premiumSteady": S=? [ "premium" ];

--- a/models/dtmcs/leader_sync/elected.pctl
+++ b/models/dtmcs/leader_sync/elected.pctl
@@ -1,3 +1,3 @@
 // A leader is eventually elected with probability 1
 // RESULT: true
-"eventuallyElected": P>=1 [ F "done" ];
+"eventuallyElected": P>=1 [ F "elected" ];

--- a/models/dtmcs/leader_sync/elected.pctl
+++ b/models/dtmcs/leader_sync/elected.pctl
@@ -1,3 +1,3 @@
 // A leader is eventually elected with probability 1
 // RESULT: true
-"elected": P>=1 [ F "done" ];
+"eventuallyElected": P>=1 [ F "done" ];


### PR DESCRIPTION
For two property files, the name given to the property clashes with a label in the corresponding model file. These changes fix this by renaming the property references.
