### PR TITLE
Typo in DTMC reachability qualitative property list

### DIFF
--- a/properties/dtmcs-reachability-qualitative.txt
+++ b/properties/dtmcs-reachability-qualitative.txt
@@ -1,1 +1,1 @@
-../models/dtmcs/leader_sync, eventually_lected.pctl
+../models/dtmcs/leader_sync, eventually_elected.pctl

--- a/properties/dtmcs-reachability-qualitative.txt
+++ b/properties/dtmcs-reachability-qualitative.txt
@@ -1,1 +1,1 @@
-../models/dtmcs/leader_sync, elected.pctl
+../models/dtmcs/leader_sync, eventually_lected.pctl


### PR DESCRIPTION
Fix an incorrect property file name; it seems the property has been updated and moved but filename in newly created dtmcs-reachability-qualitative.txt stayed the same.