### PR TITLE
Small refactoring of model files for easier parsing

### DIFF
--- a/models/dtmcs/bluetooth/bluetooth.pm
+++ b/models/dtmcs/bluetooth/bluetooth.pm
@@ -27,6 +27,11 @@ const int mrep = 128; //number of times a train is repeated before switching
 // we combine together scan and sleep when the receiver scans and hears nothing
 // the following formula is true in a state if and only if the receiver will hear something if it immediately starts scanning 
 // (receiver scans for 32 slots so one loop of a train plus 4 more steps)
+formula swap  = (((c=2)|(c=4)|(c=6)|(c=8)|(c=10)|(c=12)|(c=14)|(c=16))); // receiver swaps trains at end of sequence only when c is even
+formula swap2  = ((((c=2)|(c=4)|(c=6)|(c=8)|(c=10)|(c=12)|(c=14))) & freq=c+1) | (c=16 & freq=1) | ((((c=1)|(c=3)|(c=5)|(c=7)|(c=9)|(c=11)|(c=13)|(c=15))) & freq!=c+1); // receiver swaps trains when changing frequency set (when receiver sleeps)
+formula sleep = (receiver=0 & y1=1); // state where reciever's next time step corresponds to the whole of scan and sleep (scan interval)
+formula hear  = (freq1=freq & train1=train & send=1); // when the receiver hears something
+
 formula success = 
 	// will see on current set of frequencies and there is time to complete a whole cycle
 	((rep<mrep & ((t1=((freq<=c)?train:1-train) & f1<=c) | (t1=((freq<=c)?1-train:train) & f1>c)))
@@ -40,11 +45,6 @@ formula success =
 	| (rep=mrep & c<16 & swap  & ((t1=((freq<=c)?train:1-train) & f1<=c+1) | (t1=((freq<=c)?1-train:train) & f1>c+1)) & f1<=freq+2)
 	| (rep=mrep & c<16 & !swap & ((t1=((freq<=c)?1-train:train) & f1<=c+1) | (t1=((freq<=c)?train:1-train) & f1>c+1)) & f1<=freq+2)
 	| (rep=mrep & c=16 & (t1=((f1=1)?1-train:train)) & f1<=freq+2 & c=16));
-
-formula swap  = (((c=2)|(c=4)|(c=6)|(c=8)|(c=10)|(c=12)|(c=14)|(c=16))); // receiver swaps trains at end of sequence only when c is even
-formula swap2  = ((((c=2)|(c=4)|(c=6)|(c=8)|(c=10)|(c=12)|(c=14))) & freq=c+1) | (c=16 & freq=1) | ((((c=1)|(c=3)|(c=5)|(c=7)|(c=9)|(c=11)|(c=13)|(c=15))) & freq!=c+1); // receiver swaps trains when changing frequency set (when receiver sleeps)
-formula sleep = (receiver=0 & y1=1); // state where reciever's next time step corresponds to the whole of scan and sleep (scan interval)  
-formula hear  = (freq1=freq & train1=train & send=1); // when the receiver hears something
 
 //----------------------------------------------------------------------------------------------------------------------------
 // module for first receiver

--- a/models/dtmcs/bluetooth/time.pctl
+++ b/models/dtmcs/bluetooth/time.pctl
@@ -1,2 +1,2 @@
 // Expected time to complete the inquiry phase
-"time": R=? [ F rec=mrec {"init"}{max} ];
+"time": filter(max, R=? [ F rec=mrec ], "init");

--- a/models/dtmcs/herman/steps.pctl
+++ b/models/dtmcs/herman/steps.pctl
@@ -1,2 +1,2 @@
 // Expected number of steps until termination
-"steps": R=? [ F "stable"{"init"}{max} ];
+"steps": filter(max, R=? [ F "stable" ], "init");

--- a/models/dtmcs/leader_sync/leader_sync3_2.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_2.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 2; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 2; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync3_3.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_3.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 3; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 3; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync3_4.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_4.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 4; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 4; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync3_5.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_5.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 5; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 5; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync3_6.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_6.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 6; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 6; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync3_8.pm
+++ b/models/dtmcs/leader_sync/leader_sync3_8.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 3; // number of processes
-const K = 8; // range of probabilistic choice
+const int N = 3; // number of processes
+const int K = 8; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_2.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_2.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 2; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 2; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_3.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_3.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 3; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 3; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_4.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_4.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 4; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 4; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_5.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_5.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 5; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 5; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_6.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_6.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 6; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 6; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync4_8.pm
+++ b/models/dtmcs/leader_sync/leader_sync4_8.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 4; // number of processes
-const K = 8; // range of probabilistic choice
+const int N = 4; // number of processes
+const int K = 8; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_2.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_2.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 2; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 2; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_3.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_3.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 3; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 3; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_4.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_4.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 4; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 4; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_5.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_5.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 5; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 5; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_6.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_6.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 6; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 6; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync5_8.pm
+++ b/models/dtmcs/leader_sync/leader_sync5_8.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 5; // number of processes
-const K = 8; // range of probabilistic choice
+const int N = 5; // number of processes
+const int K = 8; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_2.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_2.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 2; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 2; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_3.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_3.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 3; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 3; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_4.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_4.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 4; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 4; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_5.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_5.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 5; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 5; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_6.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_6.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 6; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 6; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/dtmcs/leader_sync/leader_sync6_8.pm
+++ b/models/dtmcs/leader_sync/leader_sync6_8.pm
@@ -4,8 +4,8 @@
 dtmc
 
 // CONSTANTS
-const N = 6; // number of processes
-const K = 8; // range of probabilistic choice
+const int N = 6; // number of processes
+const int K = 8; // range of probabilistic choice
 
 // counter module used to count the number of processes that have been read
 // and to know when a process has decided

--- a/models/mdps/csma/csma2_2.nm
+++ b/models/mdps/csma/csma2_2.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 2; // number of processes
 const int K = 2; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma2_4.nm
+++ b/models/mdps/csma/csma2_4.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 2; // number of processes
 const int K = 4; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma2_6.nm
+++ b/models/mdps/csma/csma2_6.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 2; // number of processes
 const int K = 6; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma3_2.nm
+++ b/models/mdps/csma/csma3_2.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 3; // number of processes
 const int K = 2; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma3_4.nm
+++ b/models/mdps/csma/csma3_4.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 3; // number of processes
 const int K = 4; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma3_6.nm
+++ b/models/mdps/csma/csma3_6.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 3; // number of processes
 const int K = 6; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma4_2.nm
+++ b/models/mdps/csma/csma4_2.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 4; // number of processes
 const int K = 2; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma4_4.nm
+++ b/models/mdps/csma/csma4_4.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 4; // number of processes
 const int K = 4; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/csma/csma4_6.nm
+++ b/models/mdps/csma/csma4_6.nm
@@ -6,6 +6,10 @@ mdp
 // note made changes since cannot have strict inequalities
 // in digital clocks approach and suppose a station only sends one message
 
+// simplified parameters scaled
+const int sigma=1; // time for messages to propagate along the bus
+const int lambda=30; // time to send a message
+
 // actual parameters
 const int N = 4; // number of processes
 const int K = 6; // exponential backoff limit
@@ -13,10 +17,6 @@ const int slot = 2*sigma; // length of slot
 const int M = floor(pow(2, K))-1 ; // max number of slots to wait
 //const int lambda=782;
 //const int sigma=26;
-
-// simplified parameters scaled
-const int sigma=1; // time for messages to propagate along the bus
-const int lambda=30; // time to send a message
 
 //----------------------------------------------------------------------------------------------------------------------------
 // the bus

--- a/models/mdps/firewire/firewire.nm
+++ b/models/mdps/firewire/firewire.nm
@@ -1,6 +1,8 @@
 // firewire protocol with integer semantics
 // dxp/gxn 14/06/01
 
+mdp
+
 // CLOCKS
 // x1 (x2) clock for node1 (node2)
 // y1 and y2 (z1 and z2) clocks for wire12 (wire21)

--- a/models/mdps/firewire_impl_dl/firewire_impl_dl.nm
+++ b/models/mdps/firewire_impl_dl/firewire_impl_dl.nm
@@ -1,6 +1,8 @@
 // full firewire protocol with integer semantics
 // dxp/gxn 14/06/01
 
+mdp
+
 // CLOCKS
 // x1 clock for node1
 // x2 clock for node2

--- a/models/mdps/wlan/wlan0.nm
+++ b/models/mdps/wlan/wlan0.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =16
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 0;
+const int MAX_BACKOFF = 0;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan0.nm
+++ b/models/mdps/wlan/wlan0.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan1.nm
+++ b/models/mdps/wlan/wlan1.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =31
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 1;
+const int MAX_BACKOFF = 1;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan1.nm
+++ b/models/mdps/wlan/wlan1.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan2.nm
+++ b/models/mdps/wlan/wlan2.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =63
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 2;
+const int MAX_BACKOFF = 2;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan2.nm
+++ b/models/mdps/wlan/wlan2.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan3.nm
+++ b/models/mdps/wlan/wlan3.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =127
 // this means that MAX_BACKOFF IS 3
-const MAX_BACKOFF = 3;
+const int MAX_BACKOFF = 3;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan3.nm
+++ b/models/mdps/wlan/wlan3.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan4.nm
+++ b/models/mdps/wlan/wlan4.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =255
 // this means that MAX_BACKOFF IS 4
-const MAX_BACKOFF = 4;
+const int MAX_BACKOFF = 4;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan4.nm
+++ b/models/mdps/wlan/wlan4.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan5.nm
+++ b/models/mdps/wlan/wlan5.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =511
 // this means that MAX_BACKOFF IS 5
-const MAX_BACKOFF = 5;
+const int MAX_BACKOFF = 5;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan5.nm
+++ b/models/mdps/wlan/wlan5.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan/wlan6.nm
+++ b/models/mdps/wlan/wlan6.nm
@@ -8,21 +8,21 @@ const int COL; // maximum number of collisions
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =1023
 // this means that MAX_BACKOFF IS 6
-const MAX_BACKOFF = 6;
+const int MAX_BACKOFF = 6;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan/wlan6.nm
+++ b/models/mdps/wlan/wlan6.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // COLLISIONS
 const int COL; // maximum number of collisions
 

--- a/models/mdps/wlan_dl/wlan_dl0.nm
+++ b/models/mdps/wlan_dl/wlan_dl0.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl0.nm
+++ b/models/mdps/wlan_dl/wlan_dl0.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =16
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 0;
+const int MAX_BACKOFF = 0;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl1.nm
+++ b/models/mdps/wlan_dl/wlan_dl1.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =31
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 1;
+const int MAX_BACKOFF = 1;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl1.nm
+++ b/models/mdps/wlan_dl/wlan_dl1.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl2.nm
+++ b/models/mdps/wlan_dl/wlan_dl2.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =63
 // this means that MAX_BACKOFF IS 2
-const MAX_BACKOFF = 2;
+const int MAX_BACKOFF = 2;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl2.nm
+++ b/models/mdps/wlan_dl/wlan_dl2.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl3.nm
+++ b/models/mdps/wlan_dl/wlan_dl3.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =127
 // this means that MAX_BACKOFF IS 3
-const MAX_BACKOFF = 3;
+const int MAX_BACKOFF = 3;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl3.nm
+++ b/models/mdps/wlan_dl/wlan_dl3.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl4.nm
+++ b/models/mdps/wlan_dl/wlan_dl4.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl4.nm
+++ b/models/mdps/wlan_dl/wlan_dl4.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =255
 // this means that MAX_BACKOFF IS 4
-const MAX_BACKOFF = 4;
+const int MAX_BACKOFF = 4;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl5.nm
+++ b/models/mdps/wlan_dl/wlan_dl5.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =511
 // this means that MAX_BACKOFF IS 5
-const MAX_BACKOFF = 5;
+const int MAX_BACKOFF = 5;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl5.nm
+++ b/models/mdps/wlan_dl/wlan_dl5.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/wlan_dl/wlan_dl6.nm
+++ b/models/mdps/wlan_dl/wlan_dl6.nm
@@ -5,21 +5,21 @@
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME
-const ASLOTTIME = 1;
-const DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
-const VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
-const TRANS_TIME_MAX = 10; // scaling up
-const TRANS_TIME_MIN = 4; // scaling down
-const ACK_TO = 6; 
-const ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
-const SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int ASLOTTIME = 1;
+const int DIFS = 3; // due to scaling can be either 2 or 3 which is modelled by a non-deterministic choice
+const int VULN = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
+const int TRANS_TIME_MAX = 10; // scaling up
+const int TRANS_TIME_MIN = 4; // scaling down
+const int ACK_TO = 6;
+const int ACK = 4; // due to scaling can be either 3 or 4 which is modelled by a non-deterministic choice
+const int SIFS = 1; // due to scaling can be either 0 or 1 which is modelled by a non-deterministic choice
 // maximum constant used in timing constraints + 1
-const TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
+const int TIME_MAX = max(ACK_TO,TRANS_TIME_MAX)+1;
 
 // CONTENTION WINDOW
 // CWMIN =15 & CWMAX =1023
 // this means that MAX_BACKOFF IS 6
-const MAX_BACKOFF = 6;
+const int MAX_BACKOFF = 6;
 
 //-----------------------------------------------------------------//
 // THE MEDIUM/CHANNEL

--- a/models/mdps/wlan_dl/wlan_dl6.nm
+++ b/models/mdps/wlan_dl/wlan_dl6.nm
@@ -2,6 +2,8 @@
 // discrete time model
 // gxn/jzs 20/02/02
 
+mdp
+
 // TIMING CONSTRAINTS
 // we have used the FHSS parameters
 // then scaled by the value of ASLOTTIME

--- a/models/mdps/zeroconf/zeroconf.nm
+++ b/models/mdps/zeroconf/zeroconf.nm
@@ -3,9 +3,6 @@
 // when a number of (abstract) hosts have already got ip addresses
 // gxn/dxp/jzs 02/05/03
 
-// reset or noreset model
-const bool reset;
-
 //-------------------------------------------------------------
 
 // we suppose that
@@ -52,6 +49,9 @@ mdp
 
 //-------------------------------------------------------------
 // VARIABLES
+// reset or noreset model
+const bool reset;
+
 const int N; // number of abstract hosts
 const int K; // number of probes to send
 const double loss = 0.1; // probability of message loss

--- a/models/mdps/zeroconf_dl/zeroconf_dl.nm
+++ b/models/mdps/zeroconf_dl/zeroconf_dl.nm
@@ -3,10 +3,6 @@
 // when a number of (abstract) hosts have already got ip addresses
 // gxn/dxp/jzs 02/05/03
 
-// reset or noreset model
-const bool reset;
-const int deadline;
-
 //-------------------------------------------------------------
 
 // we suppose that
@@ -53,6 +49,10 @@ mdp
 
 //-------------------------------------------------------------
 // VARIABLES
+// reset or noreset model
+const bool reset;
+const int deadline;
+
 const int N; // number of abstract hosts
 const int K; // number of probes to send
 const double loss = 0.1; // probability of message loss


### PR DESCRIPTION
Made some small changes for easier parsing of benchmark files:
- Explicitly declared variables as 'int'
- Explicitly declared model type as 'mdp'
- Changed order of variable declarations s.t. variables are declared before used
- Updated filters to new format